### PR TITLE
Refresh events after saving calendar notes

### DIFF
--- a/WebApp/Pages/CalendarPage.razor
+++ b/WebApp/Pages/CalendarPage.razor
@@ -289,7 +289,7 @@
             };
 
             await CalendarService.Save(calendar);
-            EventDates[calendar.Date] = calendar.Note;
+            await LoadEvents();
 
             NewNote = "";
             SelectedDate = null;


### PR DESCRIPTION
## Summary
- Ensure calendar view refreshes after saving a note by reloading events
- Remove redundant manual EventDates update

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68910d77b1ec83339270cd489fb2b377